### PR TITLE
feat: add live camera preview with permission handling

### DIFF
--- a/Aperture.xcodeproj/project.pbxproj
+++ b/Aperture.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		A10000010000000000000001 /* ApertureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000001 /* ApertureApp.swift */; };
 		A10000010000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000002 /* ContentView.swift */; };
 		A10000010000000000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000003 /* Assets.xcassets */; };
+		A10000010000000000000004 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000005 /* CameraManager.swift */; };
+		A10000010000000000000005 /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000006 /* CameraPreview.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -17,6 +19,8 @@
 		A10000020000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A10000020000000000000003 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A10000020000000000000004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A10000020000000000000005 /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
+		A10000020000000000000006 /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
 		A10000020000000000000010 /* Aperture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Aperture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -44,6 +48,8 @@
 			children = (
 				A10000020000000000000001 /* ApertureApp.swift */,
 				A10000020000000000000002 /* ContentView.swift */,
+				A10000020000000000000005 /* CameraManager.swift */,
+				A10000020000000000000006 /* CameraPreview.swift */,
 				A10000020000000000000003 /* Assets.xcassets */,
 				A10000020000000000000004 /* Info.plist */,
 			);
@@ -129,6 +135,8 @@
 			files = (
 				A10000010000000000000001 /* ApertureApp.swift in Sources */,
 				A10000010000000000000002 /* ContentView.swift in Sources */,
+				A10000010000000000000004 /* CameraManager.swift in Sources */,
+				A10000010000000000000005 /* CameraPreview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -1,0 +1,70 @@
+import AVFoundation
+
+class CameraManager: NSObject, ObservableObject {
+    let session = AVCaptureSession()
+    @Published var authorizationStatus: AVAuthorizationStatus = .notDetermined
+
+    private let sessionQueue = DispatchQueue(label: "com.georgenijo.Aperture.sessionQueue")
+    private var currentInput: AVCaptureDeviceInput?
+
+    override init() {
+        super.init()
+        authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    }
+
+    func checkPermissions() {
+        authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+    }
+
+    func requestPermission() {
+        AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+            DispatchQueue.main.async {
+                self?.authorizationStatus = granted ? .authorized : .denied
+            }
+        }
+    }
+
+    func startSession() {
+        guard authorizationStatus == .authorized else { return }
+        sessionQueue.async { [weak self] in
+            self?.configureSession()
+            self?.session.startRunning()
+        }
+    }
+
+    func stopSession() {
+        sessionQueue.async { [weak self] in
+            self?.session.stopRunning()
+        }
+    }
+
+    private func configureSession() {
+        guard currentInput == nil else { return }
+
+        session.beginConfiguration()
+        session.sessionPreset = .photo
+
+        let discoverySession = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [.builtInWideAngleCamera],
+            mediaType: .video,
+            position: .back
+        )
+
+        guard let device = discoverySession.devices.first else {
+            session.commitConfiguration()
+            return
+        }
+
+        do {
+            let input = try AVCaptureDeviceInput(device: device)
+            if session.canAddInput(input) {
+                session.addInput(input)
+                currentInput = input
+            }
+        } catch {
+            print("Failed to create camera input: \(error)")
+        }
+
+        session.commitConfiguration()
+    }
+}

--- a/Aperture/CameraPreview.swift
+++ b/Aperture/CameraPreview.swift
@@ -1,0 +1,26 @@
+import AVFoundation
+import SwiftUI
+import UIKit
+
+struct CameraPreview: UIViewRepresentable {
+    let session: AVCaptureSession
+
+    func makeUIView(context: Context) -> PreviewView {
+        let view = PreviewView()
+        view.previewLayer.session = session
+        view.previewLayer.videoGravity = .resizeAspectFill
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewView, context: Context) {}
+
+    class PreviewView: UIView {
+        override class var layerClass: AnyClass {
+            AVCaptureVideoPreviewLayer.self
+        }
+
+        var previewLayer: AVCaptureVideoPreviewLayer {
+            layer as! AVCaptureVideoPreviewLayer
+        }
+    }
+}

--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -1,17 +1,78 @@
 import SwiftUI
 
 struct ContentView: View {
-    var body: some View {
-        VStack {
-            Image(systemName: "camera")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Aperture")
-        }
-        .padding()
-    }
-}
+    @StateObject private var cameraManager = CameraManager()
 
-#Preview {
-    ContentView()
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            switch cameraManager.authorizationStatus {
+            case .authorized:
+                CameraPreview(session: cameraManager.session)
+                    .ignoresSafeArea()
+
+            case .notDetermined:
+                promptView
+
+            case .denied, .restricted:
+                deniedView
+
+            @unknown default:
+                promptView
+            }
+        }
+        .onAppear {
+            cameraManager.checkPermissions()
+            if cameraManager.authorizationStatus == .authorized {
+                cameraManager.startSession()
+            } else if cameraManager.authorizationStatus == .notDetermined {
+                cameraManager.requestPermission()
+            }
+        }
+        .onDisappear {
+            cameraManager.stopSession()
+        }
+        .onChange(of: cameraManager.authorizationStatus) { _, newValue in
+            if newValue == .authorized {
+                cameraManager.startSession()
+            }
+        }
+    }
+
+    private var promptView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "camera")
+                .font(.system(size: 48))
+                .foregroundStyle(.white)
+            Text("Camera Access Required")
+                .font(.title2)
+                .foregroundStyle(.white)
+            Text("Aperture needs access to your camera to show the viewfinder.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.gray)
+                .padding(.horizontal, 40)
+        }
+    }
+
+    private var deniedView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "camera.slash")
+                .font(.system(size: 48))
+                .foregroundStyle(.white)
+            Text("Camera Access Denied")
+                .font(.title2)
+                .foregroundStyle(.white)
+            Text("Enable camera access in Settings to use Aperture.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.gray)
+                .padding(.horizontal, 40)
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `CameraManager` — manages `AVCaptureSession` with video input, handles camera permission request/check flow
- Add `CameraPreview` — `UIViewRepresentable` wrapping `AVCaptureVideoPreviewLayer` for full-screen live viewfinder
- Update `ContentView` to display live preview when authorized, permission prompt when undetermined, and denied state with Settings link

## Test plan
- [ ] Build succeeds (`xcodebuild` verified)
- [ ] Deploy to physical iPhone — live camera feed displays full-screen
- [ ] First launch prompts for camera permission
- [ ] Denying permission shows denied state with "Open Settings" button
- [ ] Granting permission shows live viewfinder immediately

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added camera preview display to the app
  * Implemented camera permission prompts and status tracking
  * Added navigation to app settings when camera access is denied
  * Integrated camera session management with app lifecycle (starts on launch, stops on exit)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->