### PR TITLE
feat: photo capture and local storage

### DIFF
--- a/Aperture.xcodeproj/project.pbxproj
+++ b/Aperture.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A10000010000000000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000003 /* Assets.xcassets */; };
 		A10000010000000000000004 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000005 /* CameraManager.swift */; };
 		A10000010000000000000005 /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000006 /* CameraPreview.swift */; };
+		A10000010000000000000006 /* PhotoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000007 /* PhotoStorage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,6 +22,7 @@
 		A10000020000000000000004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A10000020000000000000005 /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
 		A10000020000000000000006 /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
+		A10000020000000000000007 /* PhotoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoStorage.swift; sourceTree = "<group>"; };
 		A10000020000000000000010 /* Aperture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Aperture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -50,6 +52,7 @@
 				A10000020000000000000002 /* ContentView.swift */,
 				A10000020000000000000005 /* CameraManager.swift */,
 				A10000020000000000000006 /* CameraPreview.swift */,
+				A10000020000000000000007 /* PhotoStorage.swift */,
 				A10000020000000000000003 /* Assets.xcassets */,
 				A10000020000000000000004 /* Info.plist */,
 			);
@@ -137,6 +140,7 @@
 				A10000010000000000000002 /* ContentView.swift in Sources */,
 				A10000010000000000000004 /* CameraManager.swift in Sources */,
 				A10000010000000000000005 /* CameraPreview.swift in Sources */,
+				A10000010000000000000006 /* PhotoStorage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -27,9 +27,17 @@ class CameraManager: NSObject, ObservableObject {
 
     func startSession() {
         guard authorizationStatus == .authorized else { return }
+        let startTime = CFAbsoluteTimeGetCurrent()
         sessionQueue.async { [weak self] in
-            self?.configureSession()
-            self?.session.startRunning()
+            guard let self else { return }
+            let configStart = CFAbsoluteTimeGetCurrent()
+            self.configureSession()
+            print("[Timing] configureSession: \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - configStart) * 1000))ms")
+
+            let runStart = CFAbsoluteTimeGetCurrent()
+            self.session.startRunning()
+            print("[Timing] startRunning: \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - runStart) * 1000))ms")
+            print("[Timing] total startup: \(String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - startTime) * 1000))ms")
         }
     }
 

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -95,7 +95,8 @@ class CameraManager: NSObject, ObservableObject {
             } else {
                 settings = AVCapturePhotoSettings()
             }
-            settings.photoQualityPrioritization = self.photoOutput.maxPhotoQualityPrioritization
+            settings.photoQualityPrioritization = .balanced
+            print("[Capture] capturing photo...")
             self.photoOutput.capturePhoto(with: settings, delegate: self)
         }
     }

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -8,6 +8,7 @@ class CameraManager: NSObject, ObservableObject {
     private let sessionQueue = DispatchQueue(label: "com.georgenijo.Aperture.sessionQueue")
     private var currentInput: AVCaptureDeviceInput?
     private let photoOutput = AVCapturePhotoOutput()
+    private var captureStartTime: CFAbsoluteTime = 0
 
     override init() {
         super.init()
@@ -98,6 +99,7 @@ class CameraManager: NSObject, ObservableObject {
             }
             DispatchQueue.main.async { self.isCapturing = true }
             settings.photoQualityPrioritization = self.photoOutput.maxPhotoQualityPrioritization
+            self.captureStartTime = CFAbsoluteTimeGetCurrent()
             print("[Capture] capturing photo...")
             self.photoOutput.capturePhoto(with: settings, delegate: self)
         }
@@ -113,10 +115,14 @@ extension CameraManager: AVCapturePhotoCaptureDelegate {
             print("[Capture] failed: \(error)")
             return
         }
+        let processingMs = String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - captureStartTime) * 1000)
         guard let data = photo.fileDataRepresentation() else {
             print("[Capture] failed to get photo data representation")
             return
         }
+
+        let sizeMB = String(format: "%.1f", Double(data.count) / 1_000_000)
+        print("[Capture] processed in \(processingMs)ms (\(sizeMB)MB)")
 
         let fileExtension = photoOutput.availablePhotoCodecTypes.contains(.hevc) ? "heic" : "jpg"
         if let _ = PhotoStorage.savePhoto(data, fileExtension: fileExtension) {

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -87,7 +87,7 @@ class CameraManager: NSObject, ObservableObject {
             } else {
                 settings = AVCapturePhotoSettings()
             }
-            settings.photoQualityPrioritization = .quality
+            settings.photoQualityPrioritization = self.photoOutput.maxPhotoQualityPrioritization
             self.photoOutput.capturePhoto(with: settings, delegate: self)
         }
     }

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -76,6 +76,11 @@ class CameraManager: NSObject, ObservableObject {
     func capturePhoto() {
         sessionQueue.async { [weak self] in
             guard let self else { return }
+            guard self.session.isRunning,
+                  self.photoOutput.connection(with: .video) != nil else {
+                print("Cannot capture: no active video connection")
+                return
+            }
             let settings: AVCapturePhotoSettings
             if self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
                 settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -9,6 +9,7 @@ class CameraManager: NSObject, ObservableObject {
     private var currentInput: AVCaptureDeviceInput?
     private let photoOutput = AVCapturePhotoOutput()
     private var captureStartTime: CFAbsoluteTime = 0
+    private var captureInFlight = false
 
     override init() {
         super.init()
@@ -86,11 +87,13 @@ class CameraManager: NSObject, ObservableObject {
     func capturePhoto() {
         sessionQueue.async { [weak self] in
             guard let self else { return }
-            guard self.session.isRunning,
+            guard !self.captureInFlight,
+                  self.session.isRunning,
                   self.photoOutput.connection(with: .video) != nil else {
-                print("Cannot capture: no active video connection")
+                print("[Capture] skipped: \(self.captureInFlight ? "capture in flight" : "no active video connection")")
                 return
             }
+            self.captureInFlight = true
             let settings: AVCapturePhotoSettings
             if self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
                 settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
@@ -109,7 +112,10 @@ class CameraManager: NSObject, ObservableObject {
 extension CameraManager: AVCapturePhotoCaptureDelegate {
     func photoOutput(_ output: AVCapturePhotoOutput,
                      didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-        defer { DispatchQueue.main.async { self.isCapturing = false } }
+        defer {
+            sessionQueue.async { self.captureInFlight = false }
+            DispatchQueue.main.async { self.isCapturing = false }
+        }
 
         if let error {
             print("[Capture] failed: \(error)")

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -76,10 +76,13 @@ class CameraManager: NSObject, ObservableObject {
     func capturePhoto() {
         sessionQueue.async { [weak self] in
             guard let self else { return }
-            let settings = AVCapturePhotoSettings()
+            let settings: AVCapturePhotoSettings
             if self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
-                settings.photoQualityPrioritization = .quality
+                settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
+            } else {
+                settings = AVCapturePhotoSettings()
             }
+            settings.photoQualityPrioritization = .quality
             self.photoOutput.capturePhoto(with: settings, delegate: self)
         }
     }
@@ -88,9 +91,20 @@ class CameraManager: NSObject, ObservableObject {
 extension CameraManager: AVCapturePhotoCaptureDelegate {
     func photoOutput(_ output: AVCapturePhotoOutput,
                      didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-        guard let data = photo.fileDataRepresentation() else { return }
-        if let _ = PhotoStorage.savePhoto(data) {
+        if let error {
+            print("Photo capture failed: \(error)")
+            return
+        }
+        guard let data = photo.fileDataRepresentation() else {
+            print("Failed to get photo data representation")
+            return
+        }
+
+        let fileExtension = photoOutput.availablePhotoCodecTypes.contains(.hevc) ? "heic" : "jpg"
+        if let _ = PhotoStorage.savePhoto(data, fileExtension: fileExtension) {
             print("Photo saved successfully")
+        } else {
+            print("Photo save failed")
         }
     }
 }

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -3,6 +3,7 @@ import AVFoundation
 class CameraManager: NSObject, ObservableObject {
     let session = AVCaptureSession()
     @Published var authorizationStatus: AVAuthorizationStatus = .notDetermined
+    @Published var isCapturing = false
 
     private let sessionQueue = DispatchQueue(label: "com.georgenijo.Aperture.sessionQueue")
     private var currentInput: AVCaptureDeviceInput?
@@ -95,7 +96,8 @@ class CameraManager: NSObject, ObservableObject {
             } else {
                 settings = AVCapturePhotoSettings()
             }
-            settings.photoQualityPrioritization = .balanced
+            DispatchQueue.main.async { self.isCapturing = true }
+            settings.photoQualityPrioritization = self.photoOutput.maxPhotoQualityPrioritization
             print("[Capture] capturing photo...")
             self.photoOutput.capturePhoto(with: settings, delegate: self)
         }
@@ -105,20 +107,22 @@ class CameraManager: NSObject, ObservableObject {
 extension CameraManager: AVCapturePhotoCaptureDelegate {
     func photoOutput(_ output: AVCapturePhotoOutput,
                      didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        defer { DispatchQueue.main.async { self.isCapturing = false } }
+
         if let error {
-            print("Photo capture failed: \(error)")
+            print("[Capture] failed: \(error)")
             return
         }
         guard let data = photo.fileDataRepresentation() else {
-            print("Failed to get photo data representation")
+            print("[Capture] failed to get photo data representation")
             return
         }
 
         let fileExtension = photoOutput.availablePhotoCodecTypes.contains(.hevc) ? "heic" : "jpg"
         if let _ = PhotoStorage.savePhoto(data, fileExtension: fileExtension) {
-            print("Photo saved successfully")
+            print("[Capture] photo saved successfully")
         } else {
-            print("Photo save failed")
+            print("[Capture] photo save failed")
         }
     }
 }

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -6,6 +6,7 @@ class CameraManager: NSObject, ObservableObject {
 
     private let sessionQueue = DispatchQueue(label: "com.georgenijo.Aperture.sessionQueue")
     private var currentInput: AVCaptureDeviceInput?
+    private let photoOutput = AVCapturePhotoOutput()
 
     override init() {
         super.init()
@@ -65,6 +66,31 @@ class CameraManager: NSObject, ObservableObject {
             print("Failed to create camera input: \(error)")
         }
 
+        if session.canAddOutput(photoOutput) {
+            session.addOutput(photoOutput)
+        }
+
         session.commitConfiguration()
+    }
+
+    func capturePhoto() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+            let settings = AVCapturePhotoSettings()
+            if self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
+                settings.photoQualityPrioritization = .quality
+            }
+            self.photoOutput.capturePhoto(with: settings, delegate: self)
+        }
+    }
+}
+
+extension CameraManager: AVCapturePhotoCaptureDelegate {
+    func photoOutput(_ output: AVCapturePhotoOutput,
+                     didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        guard let data = photo.fileDataRepresentation() else { return }
+        if let _ = PhotoStorage.savePhoto(data) {
+            print("Photo saved successfully")
+        }
     }
 }

--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -77,13 +77,14 @@ struct ContentView: View {
         } label: {
             ZStack {
                 Circle()
-                    .fill(.white)
+                    .fill(cameraManager.isCapturing ? .gray : .white)
                     .frame(width: 70, height: 70)
                 Circle()
-                    .stroke(.white, lineWidth: 4)
+                    .stroke(cameraManager.isCapturing ? .gray : .white, lineWidth: 4)
                     .frame(width: 80, height: 80)
             }
         }
+        .disabled(cameraManager.isCapturing)
     }
 
     private var deniedView: some View {

--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var cameraManager = CameraManager()
+    @State private var showFlash = false
 
     var body: some View {
         ZStack {
@@ -11,6 +12,17 @@ struct ContentView: View {
             case .authorized:
                 CameraPreview(session: cameraManager.session)
                     .ignoresSafeArea()
+
+                VStack {
+                    Spacer()
+                    shutterButton
+                        .padding(.bottom, 40)
+                }
+
+                if showFlash {
+                    Color.white.ignoresSafeArea()
+                        .allowsHitTesting(false)
+                }
 
             case .notDetermined:
                 promptView
@@ -52,6 +64,25 @@ struct ContentView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.gray)
                 .padding(.horizontal, 40)
+        }
+    }
+
+    private var shutterButton: some View {
+        Button {
+            cameraManager.capturePhoto()
+            showFlash = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                showFlash = false
+            }
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(.white)
+                    .frame(width: 70, height: 70)
+                Circle()
+                    .stroke(.white, lineWidth: 4)
+                    .frame(width: 80, height: 80)
+            }
         }
     }
 

--- a/Aperture/PhotoStorage.swift
+++ b/Aperture/PhotoStorage.swift
@@ -18,11 +18,11 @@ struct PhotoStorage {
         }
     }
 
-    static func savePhoto(_ imageData: Data) -> String? {
+    static func savePhoto(_ imageData: Data, fileExtension: String = "jpg") -> String? {
         ensureDirectoryExists()
 
         let id = UUID().uuidString
-        let filename = "\(id).jpg"
+        let filename = "\(id).\(fileExtension)"
         let photoURL = photosDirectory.appendingPathComponent(filename)
         let metadataURL = photosDirectory.appendingPathComponent("\(id).json")
 

--- a/Aperture/PhotoStorage.swift
+++ b/Aperture/PhotoStorage.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct PhotoMetadata: Codable {
+    let filename: String
+    let timestamp: Date
+}
+
+struct PhotoStorage {
+    private static var photosDirectory: URL {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return documents.appendingPathComponent("photos", isDirectory: true)
+    }
+
+    static func ensureDirectoryExists() {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: photosDirectory.path) {
+            try? fm.createDirectory(at: photosDirectory, withIntermediateDirectories: true)
+        }
+    }
+
+    static func savePhoto(_ imageData: Data) -> String? {
+        ensureDirectoryExists()
+
+        let id = UUID().uuidString
+        let filename = "\(id).jpg"
+        let photoURL = photosDirectory.appendingPathComponent(filename)
+        let metadataURL = photosDirectory.appendingPathComponent("\(id).json")
+
+        do {
+            try imageData.write(to: photoURL)
+
+            let metadata = PhotoMetadata(filename: filename, timestamp: Date())
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let metadataData = try encoder.encode(metadata)
+            try metadataData.write(to: metadataURL)
+
+            return filename
+        } catch {
+            print("Failed to save photo: \(error)")
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AVCapturePhotoOutput` to the capture session for photo capture
- Add shutter button with white flash feedback overlay on the camera view
- Add `PhotoStorage` helper that saves JPEG photos + JSON metadata (timestamp, filename) to `Documents/photos/` in the app sandbox

## Test plan
- [ ] Build succeeds (`xcodebuild` verified)
- [ ] Deploy to device, tap shutter button — photo saves to app sandbox
- [ ] Verify `Documents/photos/` contains `.jpg` and `.json` files after capture
- [ ] Confirm flash overlay appears briefly on shutter tap

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shutter control added to the camera UI for in-app photo capture.
  * Brief white flash overlay for visual capture feedback.
  * Captured photos are saved locally with accompanying metadata (filename and timestamp).
  * Uses modern/efficient photo encoding when available and logs save success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->