### PR TITLE
feat: Photo Gallery (The Lab)

### DIFF
--- a/Aperture.xcodeproj/project.pbxproj
+++ b/Aperture.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		A10000010000000000000004 /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000005 /* CameraManager.swift */; };
 		A10000010000000000000005 /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000006 /* CameraPreview.swift */; };
 		A10000010000000000000006 /* PhotoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000007 /* PhotoStorage.swift */; };
+		A10000010000000000000007 /* LabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000008 /* LabView.swift */; };
+		A10000010000000000000008 /* PhotoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000009 /* PhotoDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +25,8 @@
 		A10000020000000000000005 /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
 		A10000020000000000000006 /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
 		A10000020000000000000007 /* PhotoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoStorage.swift; sourceTree = "<group>"; };
+		A10000020000000000000008 /* LabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabView.swift; sourceTree = "<group>"; };
+		A10000020000000000000009 /* PhotoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailView.swift; sourceTree = "<group>"; };
 		A10000020000000000000010 /* Aperture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Aperture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -53,6 +57,8 @@
 				A10000020000000000000005 /* CameraManager.swift */,
 				A10000020000000000000006 /* CameraPreview.swift */,
 				A10000020000000000000007 /* PhotoStorage.swift */,
+				A10000020000000000000008 /* LabView.swift */,
+				A10000020000000000000009 /* PhotoDetailView.swift */,
 				A10000020000000000000003 /* Assets.xcassets */,
 				A10000020000000000000004 /* Info.plist */,
 			);
@@ -141,6 +147,8 @@
 				A10000010000000000000004 /* CameraManager.swift in Sources */,
 				A10000010000000000000005 /* CameraPreview.swift in Sources */,
 				A10000010000000000000006 /* PhotoStorage.swift in Sources */,
+				A10000010000000000000007 /* LabView.swift in Sources */,
+				A10000010000000000000008 /* PhotoDetailView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aperture/CameraManager.swift
+++ b/Aperture/CameraManager.swift
@@ -4,6 +4,7 @@ class CameraManager: NSObject, ObservableObject {
     let session = AVCaptureSession()
     @Published var authorizationStatus: AVAuthorizationStatus = .notDetermined
     @Published var isCapturing = false
+    @Published var photoSaveCount = 0
 
     private let sessionQueue = DispatchQueue(label: "com.georgenijo.Aperture.sessionQueue")
     private var currentInput: AVCaptureDeviceInput?
@@ -133,6 +134,7 @@ extension CameraManager: AVCapturePhotoCaptureDelegate {
         let fileExtension = photoOutput.availablePhotoCodecTypes.contains(.hevc) ? "heic" : "jpg"
         if let _ = PhotoStorage.savePhoto(data, fileExtension: fileExtension) {
             print("[Capture] photo saved successfully")
+            DispatchQueue.main.async { self.photoSaveCount += 1 }
         } else {
             print("[Capture] photo save failed")
         }

--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ContentView: View {
     @StateObject private var cameraManager = CameraManager()
     @State private var showFlash = false
+    @State private var showLab = false
+    @State private var lastPhotoThumbnail: UIImage?
 
     var body: some View {
         ZStack {
@@ -15,8 +17,15 @@ struct ContentView: View {
 
                 VStack {
                     Spacer()
-                    shutterButton
-                        .padding(.bottom, 40)
+                    HStack {
+                        labButton
+                        Spacer()
+                        shutterButton
+                        Spacer()
+                        Color.clear.frame(width: 50, height: 50)
+                    }
+                    .padding(.horizontal, 30)
+                    .padding(.bottom, 40)
                 }
 
                 if showFlash {
@@ -50,6 +59,12 @@ struct ContentView: View {
                 cameraManager.startSession()
             }
         }
+        .fullScreenCover(isPresented: $showLab) {
+            loadLastPhotoThumbnail()
+        } content: {
+            LabView()
+        }
+        .task { loadLastPhotoThumbnail() }
     }
 
     private var promptView: some View {
@@ -64,6 +79,23 @@ struct ContentView: View {
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.gray)
                 .padding(.horizontal, 40)
+        }
+    }
+
+    private var labButton: some View {
+        Button { showLab = true } label: {
+            if let lastPhotoThumbnail {
+                Image(uiImage: lastPhotoThumbnail)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 50, height: 50)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                Image(systemName: "photo.on.rectangle")
+                    .font(.system(size: 24))
+                    .foregroundStyle(.white)
+                    .frame(width: 50, height: 50)
+            }
         }
     }
 
@@ -85,6 +117,23 @@ struct ContentView: View {
             }
         }
         .disabled(cameraManager.isCapturing)
+    }
+
+    private func loadLastPhotoThumbnail() {
+        guard let latest = PhotoStorage.loadAllPhotos().first else {
+            lastPhotoThumbnail = nil
+            return
+        }
+        let url = PhotoStorage.photoURL(for: latest.filename)
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: 100 * UIScreen.main.scale
+        ]
+        if let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+           let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) {
+            lastPhotoThumbnail = UIImage(cgImage: cgImage)
+        }
     }
 
     private var deniedView: some View {

--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -65,6 +65,9 @@ struct ContentView: View {
             LabView()
         }
         .task { loadLastPhotoThumbnail() }
+        .onChange(of: cameraManager.photoSaveCount) { _, _ in
+            loadLastPhotoThumbnail()
+        }
     }
 
     private var promptView: some View {

--- a/Aperture/LabView.swift
+++ b/Aperture/LabView.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+import ImageIO
+import UniformTypeIdentifiers
+
+struct LabView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var photos: [PhotoMetadata] = []
+    @State private var showDeleteAllConfirmation = false
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 2), count: 3)
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if photos.isEmpty {
+                    emptyState
+                } else {
+                    galleryGrid
+                }
+            }
+            .background(Color.black)
+            .navigationTitle("The Lab")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "xmark")
+                            .foregroundStyle(.white)
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button { showDeleteAllConfirmation = true } label: {
+                        Image(systemName: "trash")
+                            .foregroundStyle(.red)
+                    }
+                    .opacity(photos.isEmpty ? 0 : 1)
+                    .disabled(photos.isEmpty)
+                }
+            }
+        }
+        .onAppear {
+            photos = PhotoStorage.loadAllPhotos()
+        }
+        .confirmationDialog("Delete all photos?", isPresented: $showDeleteAllConfirmation, titleVisibility: .visible) {
+            Button("Delete All", role: .destructive) {
+                for photo in photos {
+                    PhotoStorage.deletePhoto(photo)
+                }
+                ThumbnailCache.shared.clearAll()
+                photos = []
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 48))
+                .foregroundStyle(.gray)
+            Text("No photos yet")
+                .font(.title3)
+                .foregroundStyle(.gray)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var galleryGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 2) {
+                ForEach(photos, id: \.filename) { photo in
+                    NavigationLink(value: photo) {
+                        ThumbnailView(photo: photo)
+                            .aspectRatio(1, contentMode: .fill)
+                            .clipped()
+                    }
+                }
+            }
+        }
+        .navigationDestination(for: PhotoMetadata.self) { photo in
+            PhotoDetailView(photo: photo) {
+                photos.removeAll { $0.filename == photo.filename }
+            }
+        }
+    }
+}
+
+private final class ThumbnailCache {
+    static let shared = ThumbnailCache()
+
+    private let memoryCache = NSCache<NSString, UIImage>()
+    private let queue = OperationQueue()
+    private let cacheDirectory: URL
+
+    private init() {
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        cacheDirectory = caches.appendingPathComponent("thumbnails", isDirectory: true)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        memoryCache.countLimit = 200
+        queue.maxConcurrentOperationCount = 3
+        queue.qualityOfService = .userInitiated
+    }
+
+    private func cacheFileURL(for filename: String) -> URL {
+        let id = (filename as NSString).deletingPathExtension
+        return cacheDirectory.appendingPathComponent("\(id).jpg")
+    }
+
+    func removeCachedThumbnail(for filename: String) {
+        let key = filename as NSString
+        memoryCache.removeObject(forKey: key)
+        try? FileManager.default.removeItem(at: cacheFileURL(for: filename))
+    }
+
+    func clearAll() {
+        memoryCache.removeAllObjects()
+        try? FileManager.default.removeItem(at: cacheDirectory)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
+    func loadThumbnail(for photo: PhotoMetadata, completion: @escaping (UIImage?) -> Void) {
+        let key = photo.filename as NSString
+
+        if let cached = memoryCache.object(forKey: key) {
+            completion(cached)
+            return
+        }
+
+        queue.addOperation { [self] in
+            let start = CFAbsoluteTimeGetCurrent()
+            let cachedFile = cacheFileURL(for: photo.filename)
+
+            // Try JPEG cache on disk
+            if let data = try? Data(contentsOf: cachedFile), let img = UIImage(data: data) {
+                let ms = (CFAbsoluteTimeGetCurrent() - start) * 1000
+                print("[Thumbnail] \(photo.filename) — cache hit: \(String(format: "%.1f", ms))ms")
+                self.memoryCache.setObject(img, forKey: key)
+                DispatchQueue.main.async { completion(img) }
+                return
+            }
+
+            // Decode from HEIC source and cache as JPEG
+            let sourceURL = PhotoStorage.photoURL(for: photo.filename)
+            let maxPixel = 150.0 * UIScreen.main.scale
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceShouldCacheImmediately: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: maxPixel
+            ]
+            guard let source = CGImageSourceCreateWithURL(sourceURL as CFURL, nil),
+                  let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+            let img = UIImage(cgImage: cgImage)
+
+            // Write JPEG cache to disk using CGImageDestination (avoids alpha warning)
+            if let dest = CGImageDestinationCreateWithURL(cachedFile as CFURL, UTType.jpeg.identifier as CFString, 1, nil) {
+                CGImageDestinationAddImage(dest, cgImage, [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary)
+                CGImageDestinationFinalize(dest)
+            }
+
+            let ms = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            print("[Thumbnail] \(photo.filename) — decoded: \(String(format: "%.1f", ms))ms, size: \(cgImage.width)x\(cgImage.height)")
+            self.memoryCache.setObject(img, forKey: key)
+            DispatchQueue.main.async { completion(img) }
+        }
+    }
+}
+
+private struct ThumbnailView: View {
+    let photo: PhotoMetadata
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Color.gray.opacity(0.3)
+            }
+        }
+        .onAppear {
+            guard image == nil else { return }
+            ThumbnailCache.shared.loadThumbnail(for: photo) { img in
+                image = img
+            }
+        }
+    }
+}

--- a/Aperture/PhotoDetailView.swift
+++ b/Aperture/PhotoDetailView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct PhotoDetailView: View {
+    let photo: PhotoMetadata
+    var onDelete: (() -> Void)?
+    @Environment(\.dismiss) private var dismiss
+    @State private var image: UIImage?
+    @State private var showDeleteConfirmation = false
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                ProgressView()
+                    .tint(.white)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button { showDeleteConfirmation = true } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .confirmationDialog("Delete this photo?", isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                PhotoStorage.deletePhoto(photo)
+                onDelete?()
+                dismiss()
+            }
+        }
+        .onAppear { loadImage() }
+    }
+
+    private func loadImage() {
+        let url = PhotoStorage.photoURL(for: photo.filename)
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let data = try? Data(contentsOf: url),
+                  let loaded = UIImage(data: data) else { return }
+            DispatchQueue.main.async { image = loaded }
+        }
+    }
+}

--- a/Aperture/PhotoStorage.swift
+++ b/Aperture/PhotoStorage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct PhotoMetadata: Codable {
+struct PhotoMetadata: Codable, Hashable {
     let filename: String
     let timestamp: Date
 }
@@ -16,6 +16,44 @@ struct PhotoStorage {
         if !fm.fileExists(atPath: photosDirectory.path) {
             try? fm.createDirectory(at: photosDirectory, withIntermediateDirectories: true)
         }
+    }
+
+    static func loadAllPhotos() -> [PhotoMetadata] {
+        ensureDirectoryExists()
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: photosDirectory, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return files
+            .filter { $0.pathExtension == "json" }
+            .compactMap { url in
+                guard let data = try? Data(contentsOf: url),
+                      let metadata = try? decoder.decode(PhotoMetadata.self, from: data) else {
+                    return nil
+                }
+                return metadata
+            }
+            .sorted { $0.timestamp > $1.timestamp }
+    }
+
+    static func photoURL(for filename: String) -> URL {
+        photosDirectory.appendingPathComponent(filename)
+    }
+
+    static func deletePhoto(_ metadata: PhotoMetadata) {
+        let fm = FileManager.default
+        let photoFile = photosDirectory.appendingPathComponent(metadata.filename)
+        let id = (metadata.filename as NSString).deletingPathExtension
+        let metadataFile = photosDirectory.appendingPathComponent("\(id).json")
+        try? fm.removeItem(at: photoFile)
+        try? fm.removeItem(at: metadataFile)
+
+        // Clean cached thumbnail
+        let caches = fm.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        let cachedThumb = caches.appendingPathComponent("thumbnails/\(id).jpg")
+        try? fm.removeItem(at: cachedThumb)
     }
 
     static func savePhoto(_ imageData: Data, fileExtension: String = "jpg") -> String? {


### PR DESCRIPTION
## Summary
- Add **The Lab** — a photo gallery accessible from the camera screen via a thumbnail button next to the shutter
- **LabView**: 3-column `LazyVGrid` with cached JPEG thumbnails, empty state, and delete-all functionality
- **PhotoDetailView**: Full-screen photo viewer with single photo delete
- **PhotoStorage**: `loadAllPhotos()`, `photoURL(for:)`, `deletePhoto()` methods
- **Thumbnail caching**: HEIC thumbnails decoded once and cached as JPEG on disk + `NSCache` in memory (~0.5ms cache hits vs ~400-1000ms raw HEIC decode)

## Test plan
- [ ] Open The Lab from camera screen — verify grid displays captured photos
- [ ] Tap a photo — verify full-screen detail view loads
- [ ] Delete a single photo from detail view — verify it's removed from grid
- [ ] Delete all photos — verify empty state appears
- [ ] Scroll through many photos — verify smooth scrolling with cached thumbnails
- [ ] Capture a new photo — verify Lab button updates with latest thumbnail
- [ ] Open The Lab with no photos — verify empty state message

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Lab button to the camera UI for quick gallery access.
  * Introduced a Lab gallery with 3-column grid and an empty-state view.
  * Added full-screen photo detail view with individual delete.
  * Added "delete all" with confirmation to clear the gallery.
  * Shows thumbnails (including a last-photo thumbnail on the camera) with on-disk/memory caching for faster loads and automatic refresh after photos are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->