### PR TITLE
feat: navigation between camera and gallery

### DIFF
--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -97,30 +97,37 @@ struct ContentView: View {
 
     private var labButton: some View {
         Button { showLab = true } label: {
-            ZStack(alignment: .topTrailing) {
-                if let lastPhotoThumbnail {
-                    Image(uiImage: lastPhotoThumbnail)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 50, height: 50)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                } else {
-                    Image(systemName: "photo.on.rectangle")
-                        .font(.system(size: 24))
-                        .foregroundStyle(.white)
-                        .frame(width: 50, height: 50)
-                }
-
-                if photoCount > 0 {
-                    Text("\(photoCount)")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(Capsule().fill(.red))
-                        .offset(x: 6, y: -6)
-                }
+            if let lastPhotoThumbnail {
+                Image(uiImage: lastPhotoThumbnail)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 50, height: 50)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(alignment: .topTrailing) {
+                        photoBadge
+                    }
+            } else {
+                Image(systemName: "photo.on.rectangle")
+                    .font(.system(size: 24))
+                    .foregroundStyle(.white)
+                    .frame(width: 50, height: 50)
+                    .overlay(alignment: .topTrailing) {
+                        photoBadge
+                    }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var photoBadge: some View {
+        if photoCount > 0 {
+            Text("\(photoCount)")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Capsule().fill(.red))
+                .offset(x: 6, y: -6)
         }
     }
 

--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @State private var showFlash = false
     @State private var showLab = false
     @State private var lastPhotoThumbnail: UIImage?
+    @State private var photoCount = 0
 
     var body: some View {
         ZStack {
@@ -51,8 +52,12 @@ struct ContentView: View {
                 cameraManager.requestPermission()
             }
         }
-        .onDisappear {
-            cameraManager.stopSession()
+        .onChange(of: showLab) { _, isShowingLab in
+            if isShowingLab {
+                cameraManager.stopSession()
+            } else {
+                cameraManager.startSession()
+            }
         }
         .onChange(of: cameraManager.authorizationStatus) { _, newValue in
             if newValue == .authorized {
@@ -61,12 +66,17 @@ struct ContentView: View {
         }
         .fullScreenCover(isPresented: $showLab) {
             loadLastPhotoThumbnail()
+            photoCount = PhotoStorage.loadAllPhotos().count
         } content: {
             LabView()
         }
-        .task { loadLastPhotoThumbnail() }
+        .task {
+            loadLastPhotoThumbnail()
+            photoCount = PhotoStorage.loadAllPhotos().count
+        }
         .onChange(of: cameraManager.photoSaveCount) { _, _ in
             loadLastPhotoThumbnail()
+            photoCount += 1
         }
     }
 
@@ -87,17 +97,29 @@ struct ContentView: View {
 
     private var labButton: some View {
         Button { showLab = true } label: {
-            if let lastPhotoThumbnail {
-                Image(uiImage: lastPhotoThumbnail)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 50, height: 50)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-            } else {
-                Image(systemName: "photo.on.rectangle")
-                    .font(.system(size: 24))
-                    .foregroundStyle(.white)
-                    .frame(width: 50, height: 50)
+            ZStack(alignment: .topTrailing) {
+                if let lastPhotoThumbnail {
+                    Image(uiImage: lastPhotoThumbnail)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 50, height: 50)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                } else {
+                    Image(systemName: "photo.on.rectangle")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.white)
+                        .frame(width: 50, height: 50)
+                }
+
+                if photoCount > 0 {
+                    Text("\(photoCount)")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Capsule().fill(.red))
+                        .offset(x: 6, y: -6)
+                }
             }
         }
     }

--- a/Aperture/ContentView.swift
+++ b/Aperture/ContentView.swift
@@ -65,18 +65,15 @@ struct ContentView: View {
             }
         }
         .fullScreenCover(isPresented: $showLab) {
-            loadLastPhotoThumbnail()
-            photoCount = PhotoStorage.loadAllPhotos().count
+            refreshPhotoState()
         } content: {
             LabView()
         }
         .task {
-            loadLastPhotoThumbnail()
-            photoCount = PhotoStorage.loadAllPhotos().count
+            refreshPhotoState()
         }
         .onChange(of: cameraManager.photoSaveCount) { _, _ in
-            loadLastPhotoThumbnail()
-            photoCount += 1
+            refreshPhotoState()
         }
     }
 
@@ -116,6 +113,8 @@ struct ContentView: View {
                     }
             }
         }
+        .accessibilityLabel("Lab")
+        .accessibilityValue(photoCount == 1 ? "1 photo" : "\(photoCount) photos")
     }
 
     @ViewBuilder
@@ -151,8 +150,10 @@ struct ContentView: View {
         .disabled(cameraManager.isCapturing)
     }
 
-    private func loadLastPhotoThumbnail() {
-        guard let latest = PhotoStorage.loadAllPhotos().first else {
+    private func refreshPhotoState() {
+        let photos = PhotoStorage.loadAllPhotos()
+        photoCount = photos.count
+        guard let latest = photos.first else {
             lastPhotoThumbnail = nil
             return
         }

--- a/Aperture/LabView.swift
+++ b/Aperture/LabView.swift
@@ -11,25 +11,27 @@ struct LabView: View {
 
     var body: some View {
         NavigationStack {
-            Group {
+            ZStack {
+                Color.black.ignoresSafeArea()
+
                 if photos.isEmpty {
                     emptyState
                 } else {
                     galleryGrid
                 }
             }
-            .background(Color.black)
             .navigationTitle("The Lab")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
+                ToolbarItem(placement: .cancellationAction) {
                     Button { dismiss() } label: {
                         Image(systemName: "xmark")
                             .foregroundStyle(.white)
                     }
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .primaryAction) {
                     Button { showDeleteAllConfirmation = true } label: {
                         Image(systemName: "trash")
                             .foregroundStyle(.red)
@@ -71,8 +73,9 @@ struct LabView: View {
                 ForEach(photos, id: \.filename) { photo in
                     NavigationLink(value: photo) {
                         ThumbnailView(photo: photo)
-                            .aspectRatio(1, contentMode: .fill)
+                            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                             .clipped()
+                            .aspectRatio(1, contentMode: .fit)
                     }
                 }
             }
@@ -178,7 +181,7 @@ private struct ThumbnailView: View {
             if let image {
                 Image(uiImage: image)
                     .resizable()
-                    .scaledToFill()
+                    .aspectRatio(contentMode: .fill)
             } else {
                 Color.gray.opacity(0.3)
             }

--- a/Aperture/LabView.swift
+++ b/Aperture/LabView.swift
@@ -31,13 +31,13 @@ struct LabView: View {
                             .foregroundStyle(.white)
                     }
                 }
-                ToolbarItem(placement: .primaryAction) {
-                    Button { showDeleteAllConfirmation = true } label: {
-                        Image(systemName: "trash")
-                            .foregroundStyle(.red)
+                if !photos.isEmpty {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button { showDeleteAllConfirmation = true } label: {
+                            Image(systemName: "trash")
+                                .foregroundStyle(.red)
+                        }
                     }
-                    .opacity(photos.isEmpty ? 0 : 1)
-                    .disabled(photos.isEmpty)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Added a photo count badge on the Lab button so users can see how many photos are in the gallery
- Camera session now pauses when opening the Lab and resumes when returning, preserving battery and resources
- Photo count and thumbnail refresh on Lab dismiss to reflect any deletions made in the gallery
- Fixed Lab grid layout: content no longer renders behind the navigation bar
- Fixed inconsistent thumbnail sizes with correct square-cell modifier chain

## Changes
- `ContentView.swift` — photo count badge, session pause/resume via `.onChange(of: showLab)`
- `LabView.swift` — system NavigationStack toolbar with `.toolbarBackground(.visible)`, proper square thumbnail modifiers

## Test plan
- [ ] Take several photos, verify the count badge appears and increments on the Lab button
- [ ] Open the Lab, verify the camera session stops (viewfinder should freeze/go black)
- [ ] Dismiss the Lab, verify the camera session resumes and the viewfinder is live again
- [ ] Delete a photo in the Lab, dismiss, verify the count badge and thumbnail update correctly
- [ ] With zero photos, verify no badge is shown and the placeholder icon displays
- [ ] Verify Lab grid starts below the navigation bar, not behind it
- [ ] Verify all thumbnails in the grid are uniform squares

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Photo count badge on the Lab button and last-photo thumbnail shown (placeholder when empty); thumbnail updates when photos are saved and on view open/startup.
  * Camera session now pauses when Lab opens and resumes when Lab is dismissed.

* **Improvements**
  * Lab view uses a black background, adjusted toolbar placements, primary action hides/disables when no photos.
  * Gallery/thumbnail layout and aspect handling improved for consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->